### PR TITLE
Merge Capture Activity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,37 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools">
 
-  <application
-    android:allowBackup="true"
-    android:dataExtractionRules="@xml/data_extraction_rules"
-    android:fullBackupContent="@xml/backup_rules"
-    android:icon="@mipmap/ic_launcher"
-    android:label="@string/app_name"
-    android:roundIcon="@mipmap/ic_launcher_round"
-    android:supportsRtl="true"
-    android:theme="@style/Theme.LutraLegallyDistinctPocketMonsterArena"
-    tools:targetApi="31">
-    <activity
-      android:name=".ViewMonstersActivity"
-      android:exported="false" />
-    <activity
-      android:name=".LobbyActivity"
-      android:exported="false" />
-    <activity
-      android:name=".BattleActivity"
-      android:exported="false" />
-    <activity
-      android:name="com.lutra.legallydistinctpocketmonsterarea.AdminLobbyActivity"
-      android:exported="false" />
-    <activity
-      android:name=".MainActivity"
-      android:exported="true">
-      <intent-filter>
-        <action android:name="android.intent.action.MAIN" />
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.LutraLegallyDistinctPocketMonsterArena"
+        tools:targetApi="31">
+        <activity
+            android:name=".CaptureActivity"
+            android:exported="false" />
+        <activity
+            android:name=".ViewMonstersActivity"
+            android:exported="false" />
+        <activity
+            android:name=".LobbyActivity"
+            android:exported="false" />
+        <activity
+            android:name=".BattleActivity"
+            android:exported="false" />
+        <activity
+            android:name=".AdminLobbyActivity"
+            android:exported="false" />
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
 
-        <category android:name="android.intent.category.LAUNCHER" />
-      </intent-filter>
-    </activity>
-  </application>
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,6 +16,9 @@
             android:name=".CaptureActivity"
             android:exported="false" />
         <activity
+            android:name=".LoginActivity"
+            android:exported="false" />
+        <activity
             android:name=".ViewMonstersActivity"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
@@ -19,6 +19,7 @@ public class BattleActivity extends AppCompatActivity {
 
     public static final String ENEMY_ID = "BattleActivity.ENEMY_ID";
     public static final String USER_ID = "BattleActivity.USER_ID";
+    public static final String USER_MONSTER_ID = "BattleActivity.USER_MONSTER_ID";
 
 
     private ActivityBattleBinding binding;

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
@@ -17,6 +17,10 @@ import java.util.Random;
 
 public class BattleActivity extends AppCompatActivity {
 
+    public static final String ENEMY_ID = "BattleActivity.ENEMY_ID";
+    public static final String USER_ID = "BattleActivity.USER_ID";
+
+
     private ActivityBattleBinding binding;
     private AppRepository repository;
     private int loggedInUserID = 0;

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
@@ -102,7 +102,7 @@ public class BattleActivity extends AppCompatActivity {
         //Below are default monsters for testing.
 
         binding.battleDialog.setText("");
-        userMonster = MonsterFactory.getUserMonster(repository);
+        userMonster = MonsterFactory.getUserMonster(repository, loggedInUserID);
         enemyMonster = MonsterFactory.getRandomMonster(repository);
 
         //Rolls to see which monster goes first
@@ -180,8 +180,9 @@ public class BattleActivity extends AppCompatActivity {
         } else {
             String userHP = "0/" + userMonster.getMaxHealth();
             binding.userMonsterHP.setText(userHP);
-            binding.battleDialog.append(String.format("%n%s%n%s fainted! Battle demo ends for now.",
+            binding.battleDialog.append(String.format("%n%s%n%s fainted! Time to run!",
                     userMonster.getPhrase(),userMonster.getNickname()));
+            userRun();
         }
 
     }

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/BattleActivity.java
@@ -19,7 +19,6 @@ public class BattleActivity extends AppCompatActivity {
 
     public static final String ENEMY_ID = "BattleActivity.ENEMY_ID";
     public static final String USER_ID = "BattleActivity.USER_ID";
-    public static final String USER_MONSTER_ID = "BattleActivity.USER_MONSTER_ID";
 
 
     private ActivityBattleBinding binding;

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -23,6 +23,7 @@ import java.util.Random;
 public class CaptureActivity extends AppCompatActivity {
 
     public static final String TAG = "CaptureActivity.java";
+    public static final String USER_ID = "CaptureActivity_USER_ID";
 
     private int loggedInUser;
     private int enemyID;
@@ -40,7 +41,7 @@ public class CaptureActivity extends AppCompatActivity {
         repository = AppRepository.getRepository(getApplication());
         enemyID = getIntent().getIntExtra(BattleActivity.ENEMY_ID, -1);
         //TODO: Change default value below - currently using for testing
-        loggedInUser = getIntent().getIntExtra(BattleActivity.USER_ID, 420);
+        loggedInUser = getIntent().getIntExtra(BattleActivity.USER_ID, 99);
 
         if(enemyID != -1) {
             while(enemyMonster == null) {
@@ -95,6 +96,8 @@ public class CaptureActivity extends AppCompatActivity {
         alertBuilder.setNegativeButton("No", new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                repository.deleteMonsterByMonsterId(enemyMonster.getUserMonsterId());
+
                 Intent intent = BattleActivity.intentFactory(getApplicationContext());
                 intent.putExtra(BattleActivity.USER_ID, loggedInUser);
                 startActivity(intent);
@@ -135,10 +138,11 @@ public class CaptureActivity extends AppCompatActivity {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 enemyMonster.setUserId(loggedInUser);
-                repository.insertUserMonster(enemyMonster);
+                //TODO: Remove if successful
+                //repository.insertUserMonster(enemyMonster);
 
                 Intent intent = BattleActivity.intentFactory(getApplicationContext());
-                intent.putExtra(BattleActivity.USER_ID, loggedInUser);
+                intent.putExtra(CaptureActivity.USER_ID, loggedInUser);
                 startActivity(intent);
             }
         });
@@ -160,12 +164,13 @@ public class CaptureActivity extends AppCompatActivity {
                 if(!newNickname.isEmpty() && newNickname.length() <= 12) {
                     enemyMonster.setNickname(newNickname);
                     enemyMonster.setUserId(loggedInUser);
-                    repository.insertUserMonster(enemyMonster);
+                    //TODO: Remove if successful
+                    //repository.insertUserMonster(enemyMonster);
 
                     renameDialog.dismiss();
 
                     Intent intent = BattleActivity.intentFactory(getApplicationContext());
-                    intent.putExtra(BattleActivity.USER_ID, loggedInUser);
+                    intent.putExtra(CaptureActivity.USER_ID, loggedInUser);
                     startActivity(intent);
                 } else {
                     Toast.makeText(CaptureActivity.this, "Invalid nickname.", LENGTH_SHORT).show();

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -49,13 +49,13 @@ public class CaptureActivity extends AppCompatActivity {
                     enemyMonster = repository.getUserMonsterById(enemyID);
                 } catch (RuntimeException e) {
                     Log.e(TAG, "Could not retrieve enemy monster.");
-                    enemyMonster = new UserMonster("MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
+                    enemyMonster = new UserMonster(-1, "MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
                             UserMonster.ElementalType.NORMAL, 1, 1, 1, 420, -1);
                 }
             }
         } else {
             Log.e(TAG, "Could not retrieve enemy monster.");
-            enemyMonster = new UserMonster("MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
+            enemyMonster = new UserMonster(-1, "MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
                     UserMonster.ElementalType.NORMAL, 1, 1, 1, 420, -1);
         }
 

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -88,6 +88,12 @@ public class CaptureActivity extends AppCompatActivity {
         alertBuilder.setPositiveButton("Yes", new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                //Error check to make sure we don't have MissingNO
+                if(enemyMonster.getUserMonsterId() == -1) {
+                    Intent intent = BattleActivity.intentFactory(getApplicationContext());
+                    intent.putExtra(BattleActivity.USER_ID, loggedInUser);
+                    startActivity(intent);
+                }
                 captureDialog.dismiss();
                 captureMonster();
             }

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -3,8 +3,13 @@ package com.lutra.legallydistinctpocketmonsterarea;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 
 import androidx.appcompat.app.AppCompatActivity;
+
+import com.lutra.legallydistinctpocketmonsterarea.database.AppRepository;
+import com.lutra.legallydistinctpocketmonsterarea.database.entities.UserMonster;
+import com.lutra.legallydistinctpocketmonsterarea.databinding.ActivityCaptureBinding;
 
 public class CaptureActivity extends AppCompatActivity {
 
@@ -12,11 +17,51 @@ public class CaptureActivity extends AppCompatActivity {
 
     private int loggedInUser;
     private int enemyID;
+    private UserMonster enemyMonster;
+    private AppRepository repository;
+
+    private ActivityCaptureBinding binding;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_capture);
+        binding = ActivityCaptureBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
+
+        repository = AppRepository.getRepository(getApplication());
+        enemyID = getIntent().getIntExtra(BattleActivity.ENEMY_ID, -1);
+        loggedInUser = getIntent().getIntExtra(BattleActivity.USER_ID, 0);
+
+        if(enemyID != -1) {
+            while(enemyMonster == null) {
+                try {
+                    repository.getUserMonsterById(enemyID);
+                } catch (RuntimeException e) {
+                    Log.e(TAG, "Could not retrieve enemy monster.");
+                    enemyMonster = new UserMonster("MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
+                            UserMonster.ElementalType.NORMAL, 1, 1, 1, 420, -1);
+                }
+            }
+        } else {
+            Log.e(TAG, "Could not retrieve enemy monster.");
+            enemyMonster = new UserMonster("MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
+                    UserMonster.ElementalType.NORMAL, 1, 1, 1, 420, -1);
+        }
+
+        initializeDisplay();
+
+    }
+
+    private void initializeDisplay() {
+        binding.enemyMonsterImage.setImageResource(enemyMonster.getImageID());
+        binding.enemyMonsterName.setText(enemyMonster.getNickname());
+        binding.enemyMonsterHP.setText(String.format("MAXHP: %d",enemyMonster.getMaxHealth()));
+        binding.enemyMonsterType.setText(String.format("TYPE: %s",enemyMonster.getType().name()));
+        binding.enemyMonsterAttack.setText(String.format("ATT: %d", enemyMonster.getAttack()));
+        binding.enemyMonsterDefense.setText(String.format("DEF: %d", enemyMonster.getDefense()));
+
+        binding.captureDialog.setText(String.format("%s is weakened!%n", enemyMonster.getNickname().toUpperCase()));
+        binding.captureDialog.append(String.format("Would you like to capture %s?%n%n", enemyMonster.getNickname().toUpperCase()));
     }
 
     public static Intent intentFactory(Context context) {

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -1,15 +1,24 @@
 package com.lutra.legallydistinctpocketmonsterarea;
 
+import static android.widget.Toast.LENGTH_SHORT;
+
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
+import android.widget.EditText;
+import android.widget.Toast;
 
+import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.lutra.legallydistinctpocketmonsterarea.database.AppRepository;
 import com.lutra.legallydistinctpocketmonsterarea.database.entities.UserMonster;
 import com.lutra.legallydistinctpocketmonsterarea.databinding.ActivityCaptureBinding;
+
+import java.util.Random;
+
 
 public class CaptureActivity extends AppCompatActivity {
 
@@ -30,7 +39,8 @@ public class CaptureActivity extends AppCompatActivity {
 
         repository = AppRepository.getRepository(getApplication());
         enemyID = getIntent().getIntExtra(BattleActivity.ENEMY_ID, -1);
-        loggedInUser = getIntent().getIntExtra(BattleActivity.USER_ID, 0);
+        //TODO: Change default value below - currently using for testing
+        loggedInUser = getIntent().getIntExtra(BattleActivity.USER_ID, 420);
 
         if(enemyID != -1) {
             while(enemyMonster == null) {
@@ -49,6 +59,7 @@ public class CaptureActivity extends AppCompatActivity {
         }
 
         initializeDisplay();
+        showCaptureDialog();
 
     }
 
@@ -67,5 +78,111 @@ public class CaptureActivity extends AppCompatActivity {
     public static Intent intentFactory(Context context) {
         Intent intent = new Intent(context, CaptureActivity.class);
         return intent;
+    }
+
+    private void showCaptureDialog() {
+        AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+        AlertDialog captureDialog = alertBuilder.create();
+        alertBuilder.setTitle("Capture this monster?");
+        alertBuilder.setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                captureDialog.dismiss();
+                captureMonster();
+            }
+        });
+
+        alertBuilder.setNegativeButton("No", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                Intent intent = BattleActivity.intentFactory(getApplicationContext());
+                intent.putExtra(BattleActivity.USER_ID, loggedInUser);
+                startActivity(intent);
+            }
+        });
+
+        alertBuilder.create().show();
+    }
+
+    private void captureMonster() {
+        Random rand = new Random();
+        binding.captureDialog.append("You throw a...monster...orb?\n");
+        if(rand.nextInt() % 3 == 0) {
+            binding.captureDialog.append(String.format("%s got away.%n", enemyMonster.getNickname().toUpperCase()));
+
+            Intent intent = BattleActivity.intentFactory(getApplicationContext());
+            intent.putExtra(BattleActivity.USER_ID, loggedInUser);
+            startActivity(intent);
+        } else {
+            binding.captureDialog.append(String.format("You captured %s!!!%n", enemyMonster.getNickname().toUpperCase()));
+            showRenameDialog();
+        }
+    }
+
+    private void showRenameDialog() {
+        AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+        AlertDialog renameDialog = alertBuilder.create();
+        alertBuilder.setTitle("Rename this monster?");
+        alertBuilder.setPositiveButton("Yes", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                renameDialog.dismiss();
+                renameMonster();
+            }
+        });
+
+        alertBuilder.setNegativeButton("No", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                enemyMonster.setUserId(loggedInUser);
+                repository.insertUserMonster(enemyMonster);
+
+                Intent intent = BattleActivity.intentFactory(getApplicationContext());
+                intent.putExtra(BattleActivity.USER_ID, loggedInUser);
+                startActivity(intent);
+            }
+        });
+
+        alertBuilder.create().show();
+    }
+
+    private void renameMonster() {
+        EditText editText = new EditText(this);
+        AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+        AlertDialog renameDialog = alertBuilder.create();
+        alertBuilder.setMessage("Choose a new nickname (max. 12 chars):");
+        alertBuilder.setView(editText);
+
+        alertBuilder.setPositiveButton("Confirm", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                String newNickname = editText.getText().toString();
+                if(!newNickname.isEmpty() && newNickname.length() <= 12) {
+                    enemyMonster.setNickname(newNickname);
+                    enemyMonster.setUserId(loggedInUser);
+                    repository.insertUserMonster(enemyMonster);
+
+                    renameDialog.dismiss();
+
+                    Intent intent = BattleActivity.intentFactory(getApplicationContext());
+                    intent.putExtra(BattleActivity.USER_ID, loggedInUser);
+                    startActivity(intent);
+                } else {
+                    Toast.makeText(CaptureActivity.this, "Invalid nickname.", LENGTH_SHORT).show();
+                    renameDialog.dismiss();
+                    renameMonster();
+                }
+            }
+        });
+
+        alertBuilder.setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                renameDialog.dismiss();
+                showRenameDialog();
+            }
+        });
+
+        alertBuilder.create().show();
     }
 }

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -102,7 +102,8 @@ public class CaptureActivity extends AppCompatActivity {
         alertBuilder.setNegativeButton("No", new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                repository.deleteMonsterByMonsterId(enemyMonster.getUserMonsterId());
+                //TODO: Fix the delete query below
+                //repository.deleteMonsterByMonsterId(enemyMonster.getUserMonsterId());
 
                 Intent intent = BattleActivity.intentFactory(getApplicationContext());
                 intent.putExtra(BattleActivity.USER_ID, loggedInUser);

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -1,0 +1,26 @@
+package com.lutra.legallydistinctpocketmonsterarea;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class CaptureActivity extends AppCompatActivity {
+
+    public static final String TAG = "CaptureActivity.java";
+
+    private int loggedInUser;
+    private int enemyID;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_capture);
+    }
+
+    public static Intent intentFactory(Context context) {
+        Intent intent = new Intent(context, CaptureActivity.class);
+        return intent;
+    }
+}

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/CaptureActivity.java
@@ -46,7 +46,7 @@ public class CaptureActivity extends AppCompatActivity {
         if(enemyID != -1) {
             while(enemyMonster == null) {
                 try {
-                    repository.getUserMonsterById(enemyID);
+                    enemyMonster = repository.getUserMonsterById(enemyID);
                 } catch (RuntimeException e) {
                     Log.e(TAG, "Could not retrieve enemy monster.");
                     enemyMonster = new UserMonster("MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
@@ -138,8 +138,7 @@ public class CaptureActivity extends AppCompatActivity {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 enemyMonster.setUserId(loggedInUser);
-                //TODO: Remove if successful
-                //repository.insertUserMonster(enemyMonster);
+                repository.insertUserMonster(enemyMonster);
 
                 Intent intent = BattleActivity.intentFactory(getApplicationContext());
                 intent.putExtra(CaptureActivity.USER_ID, loggedInUser);
@@ -164,8 +163,8 @@ public class CaptureActivity extends AppCompatActivity {
                 if(!newNickname.isEmpty() && newNickname.length() <= 12) {
                     enemyMonster.setNickname(newNickname);
                     enemyMonster.setUserId(loggedInUser);
-                    //TODO: Remove if successful
-                    //repository.insertUserMonster(enemyMonster);
+
+                    repository.insertUserMonster(enemyMonster);
 
                     renameDialog.dismiss();
 

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/LobbyActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/LobbyActivity.java
@@ -18,11 +18,18 @@ import androidx.core.view.WindowInsetsCompat;
 import com.lutra.legallydistinctpocketmonsterarea.databinding.ActivityLobbyBinding;
 
 public class LobbyActivity extends AppCompatActivity {
+
+    public static final String LOBBY_USER_ID = "LobbyActivity.java_LOBBY_USER_ID";
+
+    private int loggedInUserID = -1;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         ActivityLobbyBinding binding = ActivityLobbyBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
+
+        loginUser();
 
         String user_name = getIntent().getStringExtra("username");
 
@@ -34,9 +41,10 @@ public class LobbyActivity extends AppCompatActivity {
 
         binding.battleButton.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view) { //toast for testing purposes, need to implement Battle Activity
-                Toast.makeText(LobbyActivity.this, "Battle button is clicked", Toast.LENGTH_SHORT).show();
-
+            public void onClick(View view) {
+                Intent intent = BattleActivity.intentFactory(getApplicationContext());
+                intent.putExtra(LobbyActivity.LOBBY_USER_ID, loggedInUserID);
+                startActivity(intent);
             }
         });
         binding.ViewMonster.setOnClickListener(new View.OnClickListener() { //need to implement View Monster Activity
@@ -84,6 +92,16 @@ public class LobbyActivity extends AppCompatActivity {
         Intent intent = new Intent(LobbyActivity.this, LoginActivity.class);
         startActivity(intent);
         finish();
+    }
+
+    private void loginUser() {
+        if(loggedInUserID == -1) {
+            loggedInUserID =  getIntent().getIntExtra(MainActivity.MAIN_ACTIVITY_USER_ID, -1);
+        }
+
+        if(loggedInUserID == -1) {
+            loggedInUserID = getIntent().getIntExtra(BattleActivity.USER_ID, -1);
+        }
     }
 
 

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MainActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MainActivity.java
@@ -27,7 +27,7 @@ import com.lutra.legallydistinctpocketmonsterarea.database.entities.UserMonster;
 import com.lutra.legallydistinctpocketmonsterarea.databinding.ActivityMainBinding;
 
 public class MainActivity extends AppCompatActivity {
-  private static final String MAIN_ACTIVITY_USER_ID = "com.lutra.legallydistinctpocketmonsterarea.MAIN_ACTIVITY_USER_ID";
+  public static final String MAIN_ACTIVITY_USER_ID = "com.lutra.legallydistinctpocketmonsterarea.MAIN_ACTIVITY_USER_ID";
   static final String SHARED_PREFERENCE_USERID_KEY = "com.lutra.legallydistinctpocketmonsterarea.SHARED_PREFERENCE_USERID_KEY";
   static final String SAVED_INSTANCE_STATE_USERID_KEY = "com.lutra.legallydistinctpocketmonsterarea.SAVED_INSTANCE_STATE_USERID_KEY";
   private static final int LOGGED_OUT = -1;
@@ -66,7 +66,10 @@ public class MainActivity extends AppCompatActivity {
     binding.battleActivityButton.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        startActivity(BattleActivity.intentFactory(getApplicationContext()));
+        Intent intent = BattleActivity.intentFactory(getApplicationContext());
+        //Random user number for intent testing
+        intent.putExtra(MAIN_ACTIVITY_USER_ID, 49);
+        startActivity(intent);
       }
     });
 

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MainActivity.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MainActivity.java
@@ -44,5 +44,12 @@ public class MainActivity extends AppCompatActivity {
         startActivity(ViewMonstersActivity.intentFactory(getApplicationContext()));
       }
     });
+
+    binding.captureActivityButton.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        startActivity(CaptureActivity.intentFactory(getApplicationContext()));
+      }
+    });
   }
 }

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
@@ -1,5 +1,6 @@
 package com.lutra.legallydistinctpocketmonsterarea;
 
+import android.content.Intent;
 import android.content.res.Resources;
 import android.graphics.drawable.Drawable;
 import android.util.Log;
@@ -17,9 +18,9 @@ import java.util.Random;
 public abstract class MonsterFactory {
 
     private static final String TAG = "MonsterFactory.java";
+    private static final int DEFAULT_ID = 0;
     private static final int DEFAULT_USER = -1;
-
-    public static int thisMonsterID = 1;
+    private static int thisMonsterID = 10;
 
     static UserMonster getRandomMonster(AppRepository repository) {
 
@@ -34,7 +35,7 @@ public abstract class MonsterFactory {
                 allMonsters = repository.getAllMonsterTypes();
             } catch (RuntimeException e) {
                 Log.e(TAG, "Error: Unable to instantiate enemy monster.");
-                return new UserMonster("MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
+                return new UserMonster(-1, "MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
                         UserMonster.ElementalType.NORMAL, 1, 1, 1, 420, -1);
             }
         }
@@ -52,6 +53,7 @@ public abstract class MonsterFactory {
                 Math.abs(rand.nextInt() % (template.getDefenseMax() - template.getDefenseMin()));
 
         return new UserMonster(
+                thisMonsterID++,
                 template.getMonsterTypeName(),
                 template.getPhrase(),
                 template.getImageID(),
@@ -72,7 +74,7 @@ public abstract class MonsterFactory {
                 userMonsters = repository.getAllUserMonsters();
             } catch (RuntimeException e) {
                 Log.e(TAG, "Error: Unable to instantiate enemy monster.");
-                return new UserMonster("MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
+                return new UserMonster(-1, "MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,
                         UserMonster.ElementalType.NORMAL,1,1,1,420,-1);
             }
         }

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
@@ -19,6 +19,8 @@ public abstract class MonsterFactory {
     private static final String TAG = "MonsterFactory.java";
     private static final int DEFAULT_USER = -1;
 
+    public static int thisMonsterID = 1;
+
     static UserMonster getRandomMonster(AppRepository repository) {
 
         Random rand = new Random();

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
@@ -17,8 +17,9 @@ import java.util.Random;
 public abstract class MonsterFactory {
 
     private static final String TAG = "MonsterFactory.java";
+    private static final int DEFAULT_USER = -1;
 
-    static UserMonster getRandomMonster(AppRepository repository, int userID) {
+    static UserMonster getRandomMonster(AppRepository repository) {
 
         Random rand = new Random();
 
@@ -56,7 +57,7 @@ public abstract class MonsterFactory {
                 attack,
                 defense,
                 health,
-                userID,
+                DEFAULT_USER,
                 template.getMonsterTypeId()
         );
     }

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
@@ -18,9 +18,7 @@ import java.util.Random;
 public abstract class MonsterFactory {
 
     private static final String TAG = "MonsterFactory.java";
-    private static final int DEFAULT_ID = 0;
     private static final int DEFAULT_USER = -1;
-    private static int thisMonsterID = 10;
 
     static UserMonster getRandomMonster(AppRepository repository) {
 
@@ -53,7 +51,7 @@ public abstract class MonsterFactory {
                 Math.abs(rand.nextInt() % (template.getDefenseMax() - template.getDefenseMin()));
 
         return new UserMonster(
-                thisMonsterID++,
+                Math.abs(rand.nextInt()),
                 template.getMonsterTypeName(),
                 template.getPhrase(),
                 template.getImageID(),

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/MonsterFactory.java
@@ -64,12 +64,12 @@ public abstract class MonsterFactory {
         );
     }
 
-    public static UserMonster getUserMonster(AppRepository repository) {
+    public static UserMonster getUserMonster(AppRepository repository, int userID) {
         Random rand = new Random();
         ArrayList<UserMonster> userMonsters = new ArrayList<>();
         while(userMonsters.isEmpty()) {
             try {
-                userMonsters = repository.getAllUserMonsters();
+                userMonsters = repository.getUserMonstersByUserId(userID);
             } catch (RuntimeException e) {
                 Log.e(TAG, "Error: Unable to instantiate enemy monster.");
                 return new UserMonster(-1, "MISSINGNO.", "I shouldn't even exist.", R.drawable.missingno,

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppDatabase.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppDatabase.java
@@ -108,16 +108,16 @@ public abstract class AppDatabase extends RoomDatabase {
         //Starters
         UserMonsterDAO userMonsterDAO = INSTANCE.userMonsterDAO();
         userMonsterDAO.insert(new UserMonster(1, "Plantisaurus", "Yo, got any grass?", R.drawable.ld_bulbasaur_png, UserMonster.ElementalType.GRASS, 10, 7,
-            40, 0, 1));
+            40, 49, 1));
 
         userMonsterDAO.insert(new UserMonster(2, "Zappy", "BUZZZZZZZT",R.drawable.ld_pikachu, UserMonster.ElementalType.ELECTRIC, 11, 6,
-            35, 0, 2));
+            35, 49, 2));
 
         userMonsterDAO.insert(new UserMonster(3, "Splashturt", "I didn't know you liked to get wet!",R.drawable.ld_squirtle, UserMonster.ElementalType.WATER, 12, 5,
             30, 0, 3));
 
         userMonsterDAO.insert(new UserMonster(4, "Flamizord", "Burninating the countryside!",R.drawable.ld_charizard, UserMonster.ElementalType.FIRE, 13, 4,
-            25, 0, 3));
+            25, 0, 4));
 
         UserDAO userDao = INSTANCE.userDao();
         User admin = new User("admin", "admin123", true);

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppDatabase.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppDatabase.java
@@ -107,16 +107,16 @@ public abstract class AppDatabase extends RoomDatabase {
 
         //Starters
         UserMonsterDAO userMonsterDAO = INSTANCE.userMonsterDAO();
-        userMonsterDAO.insert(new UserMonster("Plantisaurus", "Yo, got any grass?", R.drawable.ld_bulbasaur_png, UserMonster.ElementalType.GRASS, 10, 7,
+        userMonsterDAO.insert(new UserMonster(1, "Plantisaurus", "Yo, got any grass?", R.drawable.ld_bulbasaur_png, UserMonster.ElementalType.GRASS, 10, 7,
             40, 0, 1));
 
-        userMonsterDAO.insert(new UserMonster("Zappy", "BUZZZZZZZT",R.drawable.ld_pikachu, UserMonster.ElementalType.ELECTRIC, 11, 6,
+        userMonsterDAO.insert(new UserMonster(2, "Zappy", "BUZZZZZZZT",R.drawable.ld_pikachu, UserMonster.ElementalType.ELECTRIC, 11, 6,
             35, 0, 2));
 
-        userMonsterDAO.insert(new UserMonster("Splashturt", "I didn't know you liked to get wet!",R.drawable.ld_squirtle, UserMonster.ElementalType.WATER, 12, 5,
+        userMonsterDAO.insert(new UserMonster(3, "Splashturt", "I didn't know you liked to get wet!",R.drawable.ld_squirtle, UserMonster.ElementalType.WATER, 12, 5,
             30, 0, 3));
 
-        userMonsterDAO.insert(new UserMonster("Flamizord", "Burninating the countryside!",R.drawable.ld_charizard, UserMonster.ElementalType.FIRE, 13, 4,
+        userMonsterDAO.insert(new UserMonster(4, "Flamizord", "Burninating the countryside!",R.drawable.ld_charizard, UserMonster.ElementalType.FIRE, 13, 4,
             25, 0, 3));
 
         UserDAO userDao = INSTANCE.userDao();

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppRepository.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppRepository.java
@@ -131,6 +131,23 @@ public class AppRepository {
     return 0L;
   }
 
+    public UserMonster getUserMonsterById(int userMonsterId) {
+        Future<UserMonster> future = AppDatabase.databaseWriteExecutor.submit(
+                new Callable<UserMonster>() {
+                    @Override
+                    public UserMonster call() throws Exception {
+                        return userMonsterDAO.getMonsterByMonsterId(userMonsterId);
+                    }
+                }
+        );
+        try {
+            return future.get();
+        } catch (InterruptedException | ExecutionException e) {
+            Log.i(LOG_TAG, "Problem getting MonsterType by ID from repository");
+        }
+        return null;
+    }
+
   public ArrayList<UserMonster> getAllUserMonsters() {
     Future<ArrayList<UserMonster>> future = AppDatabase.databaseWriteExecutor.submit(
         new Callable<ArrayList<UserMonster>>() {

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppRepository.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/AppRepository.java
@@ -193,6 +193,10 @@ public class AppRepository {
     return userMonsterDAO.getByUserIdLiveData(userId);
   }
 
+  public void deleteMonsterByMonsterId(int monsterID) {
+      userMonsterDAO.deleteMonsterByMonsterId(monsterID);
+  }
+
   public LiveData<User> getUserByUserName(String username) {
     return userDao.getUserByUserName(username);
   }

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/UserMonsterDAO.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/UserMonsterDAO.java
@@ -2,6 +2,7 @@ package com.lutra.legallydistinctpocketmonsterarea.database;
 
 import androidx.lifecycle.LiveData;
 import androidx.room.Dao;
+import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
@@ -15,6 +16,9 @@ import java.util.Map;
 public interface UserMonsterDAO {
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   long insert(UserMonster userMonster);
+
+  @Query("DELETE FROM " + AppDatabase.USER_MONSTER_TABLE + " WHERE userMonsterId = :monsterID")
+  abstract void deleteMonsterByMonsterId(int monsterID);
 
   @Query("SELECT * FROM " + AppDatabase.USER_MONSTER_TABLE)
   List<UserMonster> getAll();

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/UserMonsterDAO.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/UserMonsterDAO.java
@@ -19,6 +19,9 @@ public interface UserMonsterDAO {
   @Query("SELECT * FROM " + AppDatabase.USER_MONSTER_TABLE)
   List<UserMonster> getAll();
 
+  @Query("SELECT * FROM " + AppDatabase.USER_MONSTER_TABLE + " WHERE userMonsterId = :monsterID")
+  UserMonster getMonsterByMonsterId(int monsterID);
+
   @Query("SELECT * FROM " + AppDatabase.USER_MONSTER_TABLE + " WHERE userId = :userId")
   List<UserMonster> getByUserId(int userId);
 

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/entities/UserMonster.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/entities/UserMonster.java
@@ -3,13 +3,15 @@ package com.lutra.legallydistinctpocketmonsterarea.database.entities;
 import androidx.annotation.NonNull;
 import androidx.room.Entity;
 import androidx.room.PrimaryKey;
+
+import com.lutra.legallydistinctpocketmonsterarea.MonsterFactory;
 import com.lutra.legallydistinctpocketmonsterarea.database.AppDatabase;
 import java.util.Objects;
 import java.util.Random;
 
 @Entity(tableName = AppDatabase.USER_MONSTER_TABLE)
 public class UserMonster {
-  @PrimaryKey(autoGenerate = true)
+  @PrimaryKey
   private int userMonsterId;
   private String nickname;
   private String phrase;
@@ -32,6 +34,10 @@ public class UserMonster {
 
   public UserMonster(String nickname, String phrase, int imageID, ElementalType type, int attack, int defense, int maxHealth, int userId,
       int monsterTypeId) {
+
+    //Make sure each monster has a unique ID set during runtime every time it is instantiated, whether it is inserted into the DB or not
+    this.setUserMonsterId(MonsterFactory.thisMonsterID++);
+
     this.nickname = nickname;
     this.phrase = phrase;
     this.imageID = imageID;

--- a/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/entities/UserMonster.java
+++ b/app/src/main/java/com/lutra/legallydistinctpocketmonsterarea/database/entities/UserMonster.java
@@ -11,7 +11,7 @@ import java.util.Random;
 
 @Entity(tableName = AppDatabase.USER_MONSTER_TABLE)
 public class UserMonster {
-  @PrimaryKey
+  @PrimaryKey(autoGenerate = true)
   private int userMonsterId;
   private String nickname;
   private String phrase;
@@ -32,11 +32,11 @@ public class UserMonster {
     WATER,
   }
 
-  public UserMonster(String nickname, String phrase, int imageID, ElementalType type, int attack, int defense, int maxHealth, int userId,
+  public UserMonster(int userMonsterId, String nickname, String phrase, int imageID, ElementalType type, int attack, int defense, int maxHealth, int userId,
       int monsterTypeId) {
 
     //Make sure each monster has a unique ID set during runtime every time it is instantiated, whether it is inserted into the DB or not
-    this.setUserMonsterId(MonsterFactory.thisMonsterID++);
+    this.userMonsterId = userMonsterId;
 
     this.nickname = nickname;
     this.phrase = phrase;

--- a/app/src/main/res/layout/activity_capture.xml
+++ b/app/src/main/res/layout/activity_capture.xml
@@ -46,7 +46,7 @@
 
     <TextView
         android:id="@+id/enemyMonsterType"
-        android:layout_width="120dp"
+        android:layout_width="130dp"
         android:layout_height="22dp"
         android:textSize="18sp"
         android:text="Type: XXXXX"
@@ -84,6 +84,7 @@
         />
 
     <TextView
+        android:id="@+id/captureDialog"
         android:layout_width="match_parent"
         android:layout_height="200dp"
         app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/activity_capture.xml
+++ b/app/src/main/res/layout/activity_capture.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".CaptureActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_capture.xml
+++ b/app/src/main/res/layout/activity_capture.xml
@@ -7,4 +7,94 @@
     android:layout_height="match_parent"
     tools:context=".CaptureActivity">
 
+    <ImageView
+        android:id="@+id/enemyMonsterImage"
+        android:layout_width="120dp"
+        android:layout_height="120dp"
+        android:layout_marginTop="20dp"
+        android:layout_marginStart="20dp"
+        android:contentDescription="@string/enemy_monster_image"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:srcCompat="@tools:sample/avatars[2]" />
+
+    <TextView
+        android:id="@+id/enemyMonsterName"
+        android:layout_width="250dp"
+        android:layout_height="30dp"
+        android:text="EnemyMonsterName"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:layout_marginStart="10dp"
+        app:layout_constraintTop_toTopOf="@id/enemyMonsterImage"
+        app:layout_constraintStart_toEndOf="@id/enemyMonsterImage"
+        android:gravity="start"
+        />
+
+    <TextView
+        android:id="@+id/enemyMonsterHP"
+        android:layout_width="100dp"
+        android:layout_height="22dp"
+        android:textSize="18sp"
+        android:text="HP: XX/XX"
+        android:gravity="start"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintTop_toBottomOf="@id/enemyMonsterName"
+        app:layout_constraintStart_toEndOf="@id/enemyMonsterImage"
+        />
+
+    <TextView
+        android:id="@+id/enemyMonsterType"
+        android:layout_width="120dp"
+        android:layout_height="22dp"
+        android:textSize="18sp"
+        android:text="Type: XXXXX"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="10dp"
+        app:layout_constraintTop_toBottomOf="@id/enemyMonsterName"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/enemyMonsterHP"
+        />
+
+    <TextView
+        android:id="@+id/enemyMonsterAttack"
+        android:layout_width="100dp"
+        android:layout_height="22dp"
+        android:textSize="18sp"
+        android:text="ATT: XX"
+        android:gravity="start"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="5dp"
+        app:layout_constraintTop_toBottomOf="@id/enemyMonsterHP"
+        app:layout_constraintStart_toEndOf="@id/enemyMonsterImage"
+        />
+
+    <TextView
+        android:id="@+id/enemyMonsterDefense"
+        android:layout_width="100dp"
+        android:layout_height="22dp"
+        android:textSize="18sp"
+        android:text="DEF: XX"
+        android:gravity="start"
+        android:layout_marginStart="10dp"
+        android:layout_marginTop="5dp"
+        app:layout_constraintTop_toBottomOf="@id/enemyMonsterAttack"
+        app:layout_constraintStart_toEndOf="@id/enemyMonsterImage"
+        />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="200dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/enemyMonsterImage"
+        android:layout_marginTop="20dp"
+        android:layout_marginEnd="20dp"
+        android:layout_marginStart="20dp"
+        android:text="[EnemyMonsterName] is weakened!\nDo you want to capture [EnemyMonsterName]?\n[Username] throws a...monster...orb?\n[EnemyMonsterName] was captured!\n[EnemyMonstername] got away...\nDo you want to give a nickname to [EnemyMonsterName]?"
+        android:textSize="18sp"
+        android:textStyle="italic"
+        />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_capture.xml
+++ b/app/src/main/res/layout/activity_capture.xml
@@ -93,6 +93,7 @@
         android:layout_marginTop="20dp"
         android:layout_marginEnd="20dp"
         android:layout_marginStart="20dp"
+        android:gravity="bottom"
         android:text="[EnemyMonsterName] is weakened!\nDo you want to capture [EnemyMonsterName]?\n[Username] throws a...monster...orb?\n[EnemyMonsterName] was captured!\n[EnemyMonstername] got away...\nDo you want to give a nickname to [EnemyMonsterName]?"
         android:textSize="18sp"
         android:textStyle="italic"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -51,4 +51,15 @@
     android:id="@+id/viewMonstersActivityButton"
     />
 
+  <Button
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      app:layout_constraintTop_toBottomOf="@id/viewMonstersActivityButton"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      android:text="CaptureActivity"
+      android:textSize="24sp"
+      android:id="@+id/captureActivityButton"
+      />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
CaptureActivity is mostly complete - fully functional to user.
Defeated monster successfully stored in DB and recalled in CaptureActivity.
Able to capture and rename monster. When captured, adds current UserID to field.
Required change to UserMonster constructor to have an ID field of its own. 
Also no longer generating key. Key is now randomly generated int - very small but nonzero possibility of collision.
(Learned that the key is not generated until monster is inserted into DB, so key must be chosen at runtime to be able to be passed as extra).
Wired run button in BattleActivity and battle button in Lobby Activity.
Running now restores all monster health. Running is mandatory if current monster is defeated. Will need to implement SwitchingMonster activity for full function.
Ensured user persistence (if app stays open) across all of Lobby -> Battle -> Capture -> Battle -> etc.

Possible future improvements:
Fix delete query so monsters can be removed from DB instead of just not assigned to a user.
Add logged in user info to Saved Preferences across all activities.